### PR TITLE
Add SAEgis (arXiv 2026) to Defenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,10 @@ With the rapid advancement of Large Vision-Language Models (LVLMs), also referre
   * Zhenhao Zhu, Yue Liu, Yanpei Guo, Wenjie Qu, Cancan Chen, Yufei He, Yibo Li, Yulin Chen, Tianyi Wu, Huiying Xu, Xinzhong Zhu, Jiaheng Zhang
   * Tsinghua University, National University of Singapore, Sun Yat-sen University, Zhejiang Normal University
   * [arXiv'26]
+* **[2026.05.08]** **[Sparse Autoencoders as Plug-and-Play Firewalls for Adversarial Attack Detection in VLMs](https://arxiv.org/abs/2605.07447)**
+  * Hao Wang, Yiqun Sun, Pengfei Wei, Lawrence B. Hsieh, Daisuke Kawahara
+  * Waseda University, Magellan Technology Research Institute (MTRI)
+  * [arXiv'26]
 <h3 id="evaluations"> <img src="assets/evaluation.png" alt="Icon" width="27" style="vertical-align:middle"/> Evaluations </h3>
 
 * **[2023.11.27]** **[How Many Unicorns Are in This Image? A Safety Evaluation Benchmark for Vision LLMs](https://arxiv.org/abs/2311.16101)** [![GitHub stars](https://img.shields.io/github/stars/UCSC-VLAA/vllm-safety-benchmark?style=social)](https://github.com/UCSC-VLAA/vllm-safety-benchmark)


### PR DESCRIPTION
Adds one paper to Defenses.

Disclosure: I am an author of this paper.

**Sparse Autoencoders as Plug-and-Play Firewalls for Adversarial Attack Detection in VLMs**
Paper: https://arxiv.org/abs/2605.07447

A sparse autoencoder is attached to a frozen VLM and trained with a plain reconstruction objective; its sparse latents separate adversarially perturbed images from clean ones, so detection needs no adversarial training and no changes to the base model.

It sits alongside the detection work already in this section — MirrorCheck, PIP, HiddenDetect, and Effective and Efficient Adversarial Detection for VLMs via A Single Vector.

Entry appended at the end of Defenses to preserve the section's ascending date order, following the existing date / title / authors / affiliations / venue block format.
